### PR TITLE
Better matching for :shipit: and :+1:

### DIFF
--- a/lib/tutter/action/sppuppet.rb
+++ b/lib/tutter/action/sppuppet.rb
@@ -24,7 +24,7 @@ class Sppuppet
       pull_request_id = @data['issue']['number']
 
       merge_command = (@data['comment']['body'] == '!merge' ||
-        @data['comment']['body'].start_with?(':shipit:'))
+        @data['comment']['body'].include?(':shipit:'))
 
       return 200, 'Not a merge comment' unless merge_command
 
@@ -88,7 +88,7 @@ class Sppuppet
         end
       end
 
-      match = /^:?([+-])1:?/.match(i.body)
+      match = /.*:?([+-])1:?.*/.match(i.body)
       if match
         score = match[1] == '+' ? 1 : -1
         # pull request submitter cant +1


### PR DESCRIPTION
Previously if a comment :+1: or :shipit:, but within other text, then
it would fail matching. This commit makes the matching a bit more
tolerant of where this symbols appear within text.

Sorry, but I haven't tested this commit. I'm pretty new to ruby and
can't figure out how to run the tests, so I couldn't effectively add
new tests for this change either. If you can point me the right way
on that, I'd be happy to add some tests.
