### PR TITLE
Add support for -2 comments

### DIFF
--- a/lib/tutter/action/sppuppet.rb
+++ b/lib/tutter/action/sppuppet.rb
@@ -96,6 +96,12 @@ class Sppuppet
           votes[i.attrs[:user].attrs[:login]] = score
         end
       end
+
+      match = /^(:poop:|:hankey:|-2)/.match(i.body)
+      if match
+        msg = "Commit cannot be merged so long as a -2 comment appears in the PR."
+        return post_comment(pull_request_id, msg)
+      end
     end
 
     return 200, 'No merge comment found' unless merger


### PR DESCRIPTION
If -2, :poop:, or :hankey: appears in the PR comments, then refuse to
merge the commit. Fixes #12.
