### PR TITLE
Make sure regexes are anchored.

### DIFF
--- a/lib/tutter/action/sppuppet.rb
+++ b/lib/tutter/action/sppuppet.rb
@@ -4,8 +4,8 @@ require 'json'
 class Sppuppet
   # Match regexps
   MERGE_COMMENT = /(:shipit:|:ship:|!merge)/
-  PLUS_VOTE = /(:?\+1:?|LGTM)/         # Match :+1:, +1, and LGTM
-  MINUS_VOTE = /(:?\-1:?)/             # Match :-1: and -1
+  PLUS_VOTE = /^(:?\+1:?|LGTM)/         # Match :+1:, +1, and LGTM
+  MINUS_VOTE = /^(:?\-1:?)/             # Match :-1: and -1
   BLOCK_VOTE = /^(:poop:|:hankey:|-2)/ # Blocks merge
   INCIDENT = /jira.*INCIDENT/
 


### PR DESCRIPTION
Fixes a bug where a codecov comment match a -1 in the body of the comment, which is not intended behaviour. :D
Anchoring is preferred instead of complicating the regexes.
