### PR TITLE
Allow merges if pr.mergeable_state == 'has_hooks'

### DIFF
--- a/lib/tutter/action/sppuppet.rb
+++ b/lib/tutter/action/sppuppet.rb
@@ -134,9 +134,9 @@ class Sppuppet
       end
     end
 
-    if pr.mergeable_state != 'clean' && !incident_merge_override
-      msg = "Merge state for is not clean. Current state: #{pr.mergeable_state}\n"
-      reassure = "I will try to merge this for you when the builds turn green\n" +
+    if pr.mergeable_state != 'clean' && pr.mergeable_state != 'has_hooks' && !incident_merge_override 
+      msg = "Merge state is not clean. Current state: #{pr.mergeable_state}\n"
+      reassure = "I will try to merge this for you when the build turn green\n" +
         "If your build fails or becomes stuck for some reason, just say 'rebuild'\n" +
         'If you have an incident and want to skip the tests or the peer review, please post the link to the jira ticket.'
       if merge_command


### PR DESCRIPTION
This change allows merges to proceed even if the mergeable_state is reported as 'has_hooks'. 

In GitHub Enterprise, global pre-receive hooks can be defined that can disallow pushes. When such hooks are defined, the github api will report the mergeable_state as 'has_hooks' instead of 'clean'. The meaning of this is "You can push this merge, but the pre-receive hook may disallow it". Tutter should allow this state in the same way as a 'clean' state.