### PR TITLE
Add required "thin" gem to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,8 @@ group :development do
 end
 
 group :test do
+  gem 'json'
   gem 'rake'
   gem 'rspec'
-  gem 'json'
+  gem 'thin'
 end


### PR DESCRIPTION
Otherwise `rake` fails.

```
$ rake

An error occurred while loading ./spec/unit/tutter/action/sppuppet_spec.rb.
Failure/Error: require 'tutter'

LoadError:
  cannot load such file -- thin
# /Users/dxia/.rvm/gems/ruby-2.6.0/gems/tutter-0.0.6/lib/tutter.rb:4:in `<top (required)>'
# ./spec/spec_helper.rb:2:in `<top (required)>'
# ./spec/unit/tutter/action/sppuppet_spec.rb:1:in `<top (required)>'
# ------------------
# --- Caused by: ---
# LoadError:
#   cannot load such file -- tutter
#   ./spec/spec_helper.rb:2:in `<top (required)>'
No examples found.

$ irb
irb(main):002:0> require 'tutter'
Traceback (most recent call last):
       10: from /Users/dxia/.rvm/rubies/ruby-2.6.0/bin/irb:23:in `<main>'
        9: from /Users/dxia/.rvm/rubies/ruby-2.6.0/bin/irb:23:in `load'
        8: from /Users/dxia/.rvm/rubies/ruby-2.6.0/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
        7: from (irb):2
        6: from /Users/dxia/.rvm/rubies/ruby-2.6.0/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:34:in `require'
        5: from /Users/dxia/.rvm/rubies/ruby-2.6.0/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:130:in `rescue in require'
        4: from /Users/dxia/.rvm/rubies/ruby-2.6.0/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:130:in `require'
        3: from /Users/dxia/.rvm/gems/ruby-2.6.0/gems/tutter-0.0.6/lib/tutter.rb:4:in `<top (required)>'
        2: from /Users/dxia/.rvm/rubies/ruby-2.6.0/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        1: from /Users/dxia/.rvm/rubies/ruby-2.6.0/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
LoadError (cannot load such file -- thin)
```